### PR TITLE
Fixing test spillover workaround

### DIFF
--- a/bigsanity/table_names.py
+++ b/bigsanity/table_names.py
@@ -50,11 +50,14 @@ def monthly_tables(time_range_start, time_range_end):
         raise ValueError('time_range_end (%s) is out of range' % time_range_end)
     day_delta = relativedelta.relativedelta(days=1)
     tables = set()
-    # We add adjacent days here because a bug in BigQuery causes a handful of
-    # tests to be published in the next or previous month if their log_time is
-    # very close to the month border.
-    current_time = max(MIN_TABLE_MONTH, time_range_start - day_delta)
+    current_time = time_range_start
+
+    # We add an adjacent day here because a bug in BigQuery causes a handful of
+    # tests to be published in the preceding month if their log_time is very
+    # close to the month border (e.g. a test on 2015-12-01T00:00:05 might appear
+    # in the 2015_11 table rather than 2015_12).
     time_limit = min(MAX_TABLE_MONTH, time_range_end + day_delta)
+
     # Keep incrementing current_time by 1 day until we reach the end of the
     # range. This is not optimal for efficiency, but it is simple.
     while current_time < time_limit:

--- a/tests/test_query_construct.py
+++ b/tests/test_query_construct.py
@@ -72,7 +72,6 @@ class TableEquivalenceQueryGeneratorTest(QueryGeneratorTest):
         SELECT
             test_id
         FROM
-            plx.google:m_lab.2009_02.all,
             plx.google:m_lab.2009_03.all,
             plx.google:m_lab.2009_04.all
         WHERE
@@ -186,7 +185,6 @@ class TableEquivalenceQueryGeneratorTest(QueryGeneratorTest):
         SELECT
             test_id
         FROM
-            plx.google:m_lab.2009_02.all,
             plx.google:m_lab.2009_03.all,
             plx.google:m_lab.2009_04.all
         WHERE

--- a/tests/test_table_names.py
+++ b/tests/test_table_names.py
@@ -64,12 +64,12 @@ class TableNamesTest(unittest.TestCase):
              'plx.google:m_lab.2009_03.all'), table_names.monthly_tables(
                  datetime.datetime(2009, 2, 11), datetime.datetime(2009, 3, 1)))
 
-        # Including the 1-day buffer, 2012-01-01 spills over into the previous
+        # Including the 1-day buffer, 2012-01-01 spills over into the subsequent
         # month's table.
         self.assertSequenceEqual(
-            ('plx.google:m_lab.2011_12.all', 'plx.google:m_lab.2012_01.all',
-             'plx.google:m_lab.2012_02.all'), table_names.monthly_tables(
-                 datetime.datetime(2012, 1, 1), datetime.datetime(2012, 2, 1)))
+            ('plx.google:m_lab.2012_01.all', 'plx.google:m_lab.2012_02.all'),
+            table_names.monthly_tables(
+                datetime.datetime(2012, 1, 1), datetime.datetime(2012, 2, 1)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It turns out that tests only spill over to the previous month, so this
rmeoves the logic that assumed they could spill over into the next month
as well. This fixes issue #5.