### PR TITLE
Relax requirements around date range checking

### DIFF
--- a/bigsanity/table_names.py
+++ b/bigsanity/table_names.py
@@ -41,13 +41,21 @@ def monthly_tables(time_range_start, time_range_end):
              'plx.google:m_lab.2015_02.all',
              'plx.google:m_lab.2015_03.all']
     """
-    MIN_TABLE_MONTH = datetime.datetime.fromtimestamp(constants.MLAB_EPOCH)
+    MIN_TABLE_MONTH = datetime.datetime.fromtimestamp(
+        constants.MLAB_EPOCH).replace(day=1,
+                                      hour=0,
+                                      minute=0,
+                                      second=0,
+                                      microsecond=0)
     MAX_TABLE_MONTH = datetime.datetime.now()
     if not (MIN_TABLE_MONTH <= time_range_start <= MAX_TABLE_MONTH):
-        raise ValueError('time_range_start (%s) is out of range' %
-                         time_range_start)
+        raise ValueError(
+            'time_range_start (%s) is out of range (must be within %s to %s)' %
+            (time_range_start, MIN_TABLE_MONTH, MAX_TABLE_MONTH))
     if not (MIN_TABLE_MONTH <= time_range_end <= MAX_TABLE_MONTH):
-        raise ValueError('time_range_end (%s) is out of range' % time_range_end)
+        raise ValueError(
+            'time_range_end (%s) is out of range (must be within %s to %s)' %
+            (time_range_end, MIN_TABLE_MONTH, MAX_TABLE_MONTH))
     day_delta = relativedelta.relativedelta(days=1)
     tables = set()
     # We add adjacent days here because a bug in BigQuery causes a handful of

--- a/tests/test_table_names.py
+++ b/tests/test_table_names.py
@@ -47,10 +47,10 @@ class TableNamesTest(unittest.TestCase):
 
     def test_monthly_tables_rejects_invalid_dates(self):
         """Reject invalid table dates."""
-        # 2009-02-01 is before M-Lab epoch.
+        # 2009-01-31 is before M-Lab epoch.
         with self.assertRaises(ValueError):
             table_names.monthly_tables(
-                datetime.datetime(2009, 2, 1), datetime.datetime(2009, 3, 1))
+                datetime.datetime(2009, 1, 31), datetime.datetime(2009, 3, 1))
         # It should never be possible to generate table names for future dates.
         with self.assertRaises(ValueError):
             table_names.monthly_tables(
@@ -58,11 +58,17 @@ class TableNamesTest(unittest.TestCase):
                 datetime.datetime.now() + datetime.timedelta(days=1))
 
     def test_monthly_tables(self):
-        """Generate legacy monthly table names for valid date range."""
+        """Generate monthly table names for valid date range."""
         self.assertSequenceEqual(
             ('plx.google:m_lab.2009_02.all',
              'plx.google:m_lab.2009_03.all'), table_names.monthly_tables(
                  datetime.datetime(2009, 2, 11), datetime.datetime(2009, 3, 1)))
+
+        # Rounding down to 2009-02-01 is okay even though M-Lab epoch is
+        # 2009-02-11 because the 2009_02 table still exists.
+        self.assertSequenceEqual(
+            ('plx.google:m_lab.2009_02.all',), table_names.monthly_tables(
+                datetime.datetime(2009, 2, 1), datetime.datetime(2009, 2, 15)))
 
         # Including the 1-day buffer, 2012-01-01 spills over into the previous
         # month's table.


### PR DESCRIPTION
We currently check whether users specify a start time window that
precedes M-Lab epoch, which is 2009-02-11 because we don't have
per-month tables that precede 2009-02, but we shouldn't reject it if the
user specifies something like --start_date=2009-02-01 because we can
still query over the 2009_02 table.

This change relaxes the time window validation and accepts any start
time window going back to 2009-02-01.

Additionally this improves the error message when a user inputs an invalid
time value to print out what the expected range is.