### PR TITLE
Fixes Paris Traceroute tests to use the correct log time field

### DIFF
--- a/tests/test_query_construct.py
+++ b/tests/test_query_construct.py
@@ -284,8 +284,8 @@ class TableEquivalenceQueryGeneratorTest(unittest.TestCase):
                 plx.google:m_lab.2015_01.all
             WHERE
                 project = 3
-                AND ((web100_log_entry.log_time >= 1419724800) AND  -- 2014-12-28
-                     (web100_log_entry.log_time <  1420243200))     -- 2015-01-03
+                AND ((log_time >= 1419724800) AND  -- 2014-12-28
+                     (log_time <  1420243200))     -- 2015-01-03
           ) AS per_month
         FULL OUTER JOIN EACH
           (
@@ -294,8 +294,8 @@ class TableEquivalenceQueryGeneratorTest(unittest.TestCase):
             FROM
                 plx.google:m_lab.paris_traceroute.all
             WHERE
-                ((web100_log_entry.log_time >= 1419724800) AND  -- 2014-12-28
-                 (web100_log_entry.log_time <  1420243200))     -- 2015-01-03
+                ((log_time >= 1419724800) AND  -- 2014-12-28
+                 (log_time <  1420243200))     -- 2015-01-03
           ) AS per_project
         ON
             per_month.test_id=per_project.test_id


### PR DESCRIPTION
This fixes BigQuery SQL generation so that when checking Paris
Traceroute tests, we use log_time instead of web100_log_entry.log_time
because Paris Traceroute is not web100-based.

This fixes #6.