### PR TITLE
Remove batch mode option for BQ queries

### DIFF
--- a/bigsanity/query_execution.py
+++ b/bigsanity/query_execution.py
@@ -55,7 +55,7 @@ class QueryExecutor(object):
             The result of the query in CSV format.
         """
         bq_params = [
-            'query', '--format=csv', '--batch', '--headless', '--quiet',
+            'query', '--format=csv', '--headless', '--quiet',
             '--max_rows=2000000000'
         ]
         try:


### PR DESCRIPTION
Temporarily removing batch mode so that we can do an initial sanity
check without the perf penalty of batch mode.

Re-adding this in the future. This is tracked as issue #20.