### PR TITLE
Trims the size of check failure messages when there are many test_ids

### DIFF
--- a/bigsanity/check_table_equivalence.py
+++ b/bigsanity/check_table_equivalence.py
@@ -71,7 +71,7 @@ def _format_test_ids(test_ids):
         unique_test_ids.append(
             '(%s additional or duplicate test_id values omitted)' %
             number_omitted_ids)
-    return formatting.indent('\n'.join(unique_test_ids))
+    return formatting.indent('\n'.join(unique_test_ids), 2)
 
 
 def _format_check_failure_message(per_month_ids, per_project_ids, query):
@@ -96,7 +96,7 @@ def _format_check_failure_message(per_month_ids, per_project_ids, query):
         message += ('test_id values present in per-project table, but NOT '
                     'present in per-month table:\n')
         message += '%s\n' % _format_test_ids(per_project_ids)
-    message += 'BigQuery SQL:\n%s' % formatting.indent(query)
+    message += 'BigQuery SQL:\n%s' % formatting.indent(query, 2)
     return message
 
 


### PR DESCRIPTION
The list of mismatched test_id values can get very long (like thousands
of entries long for a single check). It's not useful to print the full
list to the console, so this adds intelligence to trim down the list
into a manageable size of no more than 10 items, with duplicates
removed.